### PR TITLE
feat: Add MP4 generation for C4D image sequence reviews

### DIFF
--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -1,12 +1,16 @@
 """Library functions for Cinema4d."""
+import collections
 import contextlib
+import logging
 import math
+import os
 import json
 import re
+import subprocess
 
 import c4d
 
-from ayon_core.lib import NumberDef
+from ayon_core.lib import NumberDef, get_ffmpeg_tool_args
 
 AYON_CONTAINERS = "AYON_CONTAINERS"
 JSON_PREFIX = "JSON::"
@@ -557,3 +561,92 @@ def createPlayblastRenderData():
     # Insert the RenderData object into the document
     doc.InsertRenderData(render_data)
     return render_data
+
+
+def collect_sequences(files):
+    """
+    Group files into sequences.
+    Returns dict: { "sequence_key": [files...] }
+    For single files (like mp4), key is filename.
+    """
+    sequences = collections.defaultdict(list)
+
+    # Regex to match frame numbers at end of name before extension
+    # e.g. name.0001.ext or name0001.ext
+    frame_pattern = re.compile(r'^(.*?)(\.?\d+)(\.[^.]+)$')
+
+    for f in files:
+        match = frame_pattern.match(f)
+        if match:
+            prefix, frame, ext = match.groups()
+            # Use prefix + ext as key
+            key = f"{prefix}#{ext}"
+            sequences[key].append(f)
+        else:
+            # Single file or unrecognised pattern
+            sequences[f].append(f)
+
+    return sequences
+
+
+def generate_review(files, output_path, fps=24):
+    """
+    Generate MP4 review from a list of image files using ffmpeg.
+
+    Args:
+        files (list): List of image filenames.
+        output_path (str): Full path to output MP4 file.
+        fps (float): Frame rate.
+    """
+    log = logging.getLogger(__name__)
+
+    if not files:
+        log.warning("No files provided for review generation.")
+        return
+
+    # Sort files to ensure order
+    files.sort()
+
+    # Create a list file for ffmpeg concat
+    list_file_path = os.path.join(os.path.dirname(output_path), "ffmpeg_list.txt")
+    with open(list_file_path, "w") as f:
+        for file in files:
+            # Escape single quotes in filename
+            safe_file = file.replace("'", "'\\''")
+            f.write(f"file '{safe_file}'\n")
+
+    # Get ffmpeg args
+    # get_ffmpeg_tool_args returns something like ["path/to/ffmpeg"]
+    # We construct the command
+    ffmpeg_cmd = get_ffmpeg_tool_args("ffmpeg")
+
+    cmd = ffmpeg_cmd + [
+        "-y",  # Overwrite
+        "-r", str(fps),  # Input fps
+        "-f", "concat",
+        "-safe", "0",
+        "-i", list_file_path,
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",  # Ensure even dimensions
+        output_path
+    ]
+
+    log.info(f"Running ffmpeg: {' '.join(cmd)}")
+
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        log.info(f"Review generated at {output_path}")
+    except subprocess.CalledProcessError as e:
+        log.error(f"FFmpeg failed: {e.stderr.decode()}")
+        raise
+    finally:
+        if os.path.exists(list_file_path):
+            os.remove(list_file_path)
+
+    return output_path

--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -650,3 +650,38 @@ def generate_review(files, output_path, fps=24):
             os.remove(list_file_path)
 
     return output_path
+
+
+def generate_thumbnail(source_file, output_path):
+    """
+    Generate a thumbnail (JPG) from a source image file using ffmpeg.
+
+    Args:
+        source_file (str): Path to source image.
+        output_path (str): Path to output JPG.
+    """
+    log = logging.getLogger(__name__)
+
+    ffmpeg_cmd = get_ffmpeg_tool_args("ffmpeg")
+
+    cmd = ffmpeg_cmd + [
+        "-y",
+        "-i", source_file,
+        "-vframes", "1",
+        output_path
+    ]
+
+    log.info(f"Generating thumbnail: {' '.join(cmd)}")
+
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+    except subprocess.CalledProcessError as e:
+        log.error(f"FFmpeg thumbnail generation failed: {e.stderr.decode()}")
+        raise
+
+    return output_path

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -194,15 +194,23 @@ class ExtractRedshiftRender(publish.Extractor):
             instance.data.setdefault("representations", []).append(repre)
 
             # Generate review from sequence
-            if ext not in ["mp4", "mov"] and len(seq_files) > 1 and not is_alpha:
+            # Only generate review for main pass (prefix matches filename_base)
+            prefix = seq_name.split("#")[0]
+            if (
+                ext not in ["mp4", "mov"]
+                and len(seq_files) > 1
+                and not is_alpha
+                and prefix == filename_base
+            ):
                 review_filename = f"{filename_base}_review.mp4"
                 review_path = os.path.join(staging_dir, review_filename)
                 try:
                     lib.generate_review(seq_files, review_path, fps=fps)
 
                     review_repre = {
-                        "name": "mp4",
+                        "name": "review",
                         "ext": "mp4",
+                        "outputName": "review",
                         "files": review_filename,
                         "stagingDir": staging_dir,
                         "tags": ["review", "ftrackreview"]

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -64,7 +64,6 @@ class ExtractRedshiftRender(publish.Extractor):
         # Thumbnail Setup
         thumb_filename = "thumbnail.jpg"
         thumb_path = os.path.join(staging_dir, thumb_filename)
-        thumbnail_frame = int(frame_start) + (int(frame_end) - int(frame_start)) // 2
 
         try:
             # Modify the RenderData Object Directly
@@ -125,9 +124,6 @@ class ExtractRedshiftRender(publish.Extractor):
                 if res != c4d.RENDERRESULT_OK:
                     raise RuntimeError(f"Render failed for frame {frame} with error {res}")
 
-                # Save thumbnail
-                if frame == thumbnail_frame:
-                    bmp.Save(thumb_path, c4d.FILTER_JPG, c4d.BaseContainer(), c4d.SAVEBIT_ALPHA)
 
 
         finally:
@@ -155,6 +151,25 @@ class ExtractRedshiftRender(publish.Extractor):
         # Verify if any render files (other than review) were generated
         if not sequences:
              self.log.error("No render output files found. Redshift may have failed to save images, or the output path is incorrect.")
+
+        # Identify main sequence for thumbnail
+        main_seq_files = None
+        for seq_name, seq_files in sequences.items():
+             prefix = seq_name.split("#")[0]
+             is_alpha = os.path.basename(seq_files[0]).lower().startswith("a_")
+             if prefix == filename_base and not is_alpha and len(seq_files) > 0:
+                  main_seq_files = seq_files
+                  break
+
+        # Generate thumbnail from main sequence if it doesn't exist
+        if main_seq_files and not os.path.exists(thumb_path):
+            try:
+                middle_index = len(main_seq_files) // 2
+                source_file = main_seq_files[middle_index]
+                source_path = os.path.join(staging_dir, source_file)
+                lib.generate_thumbnail(source_path, thumb_path)
+            except Exception as e:
+                self.log.warning(f"Failed to generate thumbnail: {e}")
 
         # Add thumbnail representation if it exists
         if os.path.exists(thumb_path):
@@ -208,11 +223,11 @@ class ExtractRedshiftRender(publish.Extractor):
                     lib.generate_review(seq_files, review_path, fps=fps)
 
                     review_repre = {
-                        "name": "review",
+                        "name": "mp4",
                         "ext": "mp4",
-                        "outputName": "review",
                         "files": review_filename,
                         "stagingDir": staging_dir,
+                        "preview": True,
                         "tags": ["review", "ftrackreview"]
                     }
                     instance.data["representations"].append(review_repre)

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -61,22 +61,10 @@ class ExtractRedshiftRender(publish.Extractor):
         bmp = c4d.bitmaps.BaseBitmap()
         bmp.Init(width, height)
 
-        # Initialize MovieSaver for Review
-        review_filename = f"{filename_base}_review.mp4"
-        review_path = os.path.join(staging_dir, review_filename)
-
         # Thumbnail Setup
         thumb_filename = "thumbnail.jpg"
         thumb_path = os.path.join(staging_dir, thumb_filename)
         thumbnail_frame = int(frame_start) + (int(frame_end) - int(frame_start)) // 2
-
-        ms = c4d.bitmaps.MovieSaver()
-        # MP4 format ID is 1125
-        FILTER_MP4 = 1125
-
-        if ms.Open(review_path, bmp, fps, FILTER_MP4, c4d.BaseContainer(), c4d.SAVEBIT_ALPHA) != c4d.IMAGERESULT_OK:
-             self.log.warning("Could not open MovieSaver for review generation. Review will not be created.")
-             ms = None
 
         try:
             # Modify the RenderData Object Directly
@@ -141,17 +129,8 @@ class ExtractRedshiftRender(publish.Extractor):
                 if frame == thumbnail_frame:
                     bmp.Save(thumb_path, c4d.FILTER_JPG, c4d.BaseContainer(), c4d.SAVEBIT_ALPHA)
 
-                # Write to review
-                # Note: Color management is skipped here (Linear -> sRGB conversion absent).
-                # The review will be raw linear if source is EXR.
-                # Improving this requires OCIO which is not currently available in this scope.
-                if ms:
-                    ms.Write(bmp)
 
         finally:
-            if ms:
-                ms.Close()
-
             # Restore previous active render data
             if prev_active_rd:
                 doc.SetActiveRenderData(prev_active_rd)
@@ -171,14 +150,11 @@ class ExtractRedshiftRender(publish.Extractor):
         if thumb_filename in files:
             files.remove(thumb_filename)
 
-        sequences = self.collect_sequences(files)
+        sequences = lib.collect_sequences(files)
 
         # Verify if any render files (other than review) were generated
-        render_files_found = any(k != f"{filename_base}_review.mp4" for k in sequences.keys())
-        if not render_files_found:
+        if not sequences:
              self.log.error("No render output files found. Redshift may have failed to save images, or the output path is incorrect.")
-             # We don't raise here to allow review to publish if it exists, but it's suspicious.
-             # Actually, if the main render failed, we should probably fail.
 
         # Add thumbnail representation if it exists
         if os.path.exists(thumb_path):
@@ -195,22 +171,12 @@ class ExtractRedshiftRender(publish.Extractor):
             if not seq_files:
                 continue
 
-            seq_files.sort()
+            # Sort files
+            if isinstance(seq_files, list):
+                seq_files.sort()
 
-            # Determine if this is the review file
-            if seq_name == f"{filename_base}_review.mp4":
-                repre = {
-                    "name": "mp4",
-                    "ext": "mp4",
-                    "files": seq_name,
-                    "stagingDir": staging_dir,
-                    "tags": ["review", "ftrackreview"]
-                }
-                instance.data.setdefault("representations", []).append(repre)
-                continue
-
-            # It's a sequence
-            ext = os.path.splitext(seq_files[0])[1].lstrip(".")
+            # Identify extension
+            ext = os.path.splitext(seq_files[0])[1].lstrip(".").lower()
 
             repre = {
                 "name": ext,
@@ -220,6 +186,25 @@ class ExtractRedshiftRender(publish.Extractor):
             }
 
             instance.data.setdefault("representations", []).append(repre)
+
+            # Generate review from sequence
+            if ext not in ["mp4", "mov"] and len(seq_files) > 1:
+                review_filename = f"{filename_base}_review.mp4"
+                review_path = os.path.join(staging_dir, review_filename)
+                try:
+                    lib.generate_review(seq_files, review_path, fps=fps)
+
+                    review_repre = {
+                        "name": "mp4",
+                        "ext": "mp4",
+                        "files": review_filename,
+                        "stagingDir": staging_dir,
+                        "tags": ["review", "ftrackreview"]
+                    }
+                    instance.data["representations"].append(review_repre)
+                    self.log.info(f"Generated review mp4: {review_path}")
+                except Exception as e:
+                    self.log.error(f"Failed to generate review mp4: {e}")
 
     def get_c4d_format(self, ext):
         formats = {
@@ -231,30 +216,3 @@ class ExtractRedshiftRender(publish.Extractor):
         }
         return formats.get(ext, 1016606)
 
-    def collect_sequences(self, files):
-        """
-        Group files into sequences.
-        Returns dict: { "sequence_key": [files...] }
-        For single files (like mp4), key is filename.
-        """
-        import collections
-        import re
-
-        sequences = collections.defaultdict(list)
-
-        # Regex to match frame numbers at end of name before extension
-        # e.g. name.0001.ext or name0001.ext
-        frame_pattern = re.compile(r'^(.*?)(\.?\d+)(\.[^.]+)$')
-
-        for f in files:
-            match = frame_pattern.match(f)
-            if match:
-                prefix, frame, ext = match.groups()
-                # Use prefix + ext as key
-                key = f"{prefix}#{ext}"
-                sequences[key].append(f)
-            else:
-                # Single file or unrecognised pattern
-                sequences[f].append(f)
-
-        return sequences

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -178,17 +178,23 @@ class ExtractRedshiftRender(publish.Extractor):
             # Identify extension
             ext = os.path.splitext(seq_files[0])[1].lstrip(".").lower()
 
+            # Check for Alpha sequence
+            is_alpha = os.path.basename(seq_files[0]).lower().startswith("a_")
+
             repre = {
-                "name": ext,
+                "name": "alpha" if is_alpha else ext,
                 "ext": ext,
                 "files": seq_files if len(seq_files) > 1 else seq_files[0],
                 "stagingDir": staging_dir,
             }
 
+            if is_alpha:
+                repre["outputName"] = "alpha"
+
             instance.data.setdefault("representations", []).append(repre)
 
             # Generate review from sequence
-            if ext not in ["mp4", "mov"] and len(seq_files) > 1:
+            if ext not in ["mp4", "mov"] and len(seq_files) > 1 and not is_alpha:
                 review_filename = f"{filename_base}_review.mp4"
                 review_path = os.path.join(staging_dir, review_filename)
                 try:

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -48,17 +48,58 @@ class Cinema4DExtractReview(publish.Extractor):
             kwargs.update({"fileformat": fileformat})
 
         exporters.render_playblast(path, **kwargs)
-        
-        # Create the full filename with the extension
-        full_filename = f"{filename}.{fileformat}"
 
-        representation = {
-            "name": fileformat,
-            "ext": fileformat,
-            "files": full_filename,
-            "stagingDir": dir_path,
-        }
-        representation["tags"] = ["review", "preview", "ftrackreview"]
-        instance.data.setdefault("representations", []).append(representation)
+        # Collect the files
+        files = os.listdir(dir_path)
+        sequences = lib.collect_sequences(files)
 
-        self.log.info(f"Extracted instance '{instance.name}' to: {path}.{fileformat}")
+        for seq_name, seq_files in sequences.items():
+            if not seq_files:
+                continue
+
+            # Sort files
+            if isinstance(seq_files, list):
+                seq_files.sort()
+
+            # Identify extension
+            ext = os.path.splitext(seq_files[0])[1].lstrip(".").lower()
+
+            # Main representation (sequence or movie)
+            representation = {
+                "name": ext,
+                "ext": ext,
+                "files": seq_files if len(seq_files) > 1 else seq_files[0],
+                "stagingDir": dir_path,
+            }
+
+            # If it is a video file, tag it as review
+            if ext in ["mp4", "mov"]:
+                representation["tags"] = ["review", "preview", "ftrackreview"]
+
+            instance.data.setdefault("representations", []).append(representation)
+
+            # If it is an image sequence, we want to generate a review MP4
+            if ext not in ["mp4", "mov"] and len(seq_files) > 1:
+                # Generate review
+                review_filename = f"{filename}.mp4"
+                review_path = os.path.join(dir_path, review_filename)
+
+                # FPS
+                fps = instance.data.get("fps", doc.GetFps())
+
+                try:
+                    lib.generate_review(seq_files, review_path, fps=fps)
+
+                    review_repre = {
+                        "name": "mp4",
+                        "ext": "mp4",
+                        "files": review_filename,
+                        "stagingDir": dir_path,
+                        "tags": ["review", "preview", "ftrackreview"]
+                    }
+                    instance.data["representations"].append(review_repre)
+                    self.log.info(f"Generated review mp4: {review_path}")
+                except Exception as e:
+                    self.log.error(f"Failed to generate review mp4: {e}")
+
+        self.log.info(f"Extracted instance '{instance.name}'")

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -124,8 +124,9 @@ class Cinema4DExtractReview(publish.Extractor):
                     lib.generate_review(seq_files, review_path, fps=fps)
 
                     review_repre = {
-                        "name": "mp4",
+                        "name": "review",
                         "ext": "mp4",
+                        "outputName": "review",
                         "files": review_filename,
                         "stagingDir": dir_path,
                         "tags": ["review", "ftrackreview"]

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -84,6 +84,32 @@ class Cinema4DExtractReview(publish.Extractor):
 
             instance.data.setdefault("representations", []).append(representation)
 
+            # Generate thumbnail if not alpha and sequence
+            if not is_alpha and len(seq_files) > 0:
+                thumb_filename = "thumbnail.jpg"
+                thumb_path = os.path.join(dir_path, thumb_filename)
+
+                # Check if thumbnail already exists (e.g. from previous loop)
+                if not os.path.exists(thumb_path):
+                    # Pick middle frame
+                    middle_index = len(seq_files) // 2
+                    source_file = seq_files[middle_index]
+                    source_path = os.path.join(dir_path, source_file)
+
+                    try:
+                        lib.generate_thumbnail(source_path, thumb_path)
+
+                        thumb_repre = {
+                            "name": "thumbnail",
+                            "ext": "jpg",
+                            "files": thumb_filename,
+                            "stagingDir": dir_path,
+                            "tags": ["thumbnail"]
+                        }
+                        instance.data.setdefault("representations", []).append(thumb_repre)
+                    except Exception as e:
+                        self.log.warning(f"Failed to generate thumbnail: {e}")
+
             # If it is an image sequence, we want to generate a review MP4
             # Skip alpha sequences for review generation
             if ext not in ["mp4", "mov"] and len(seq_files) > 1 and not is_alpha:

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -124,11 +124,11 @@ class Cinema4DExtractReview(publish.Extractor):
                     lib.generate_review(seq_files, review_path, fps=fps)
 
                     review_repre = {
-                        "name": "review",
+                        "name": "mp4",
                         "ext": "mp4",
-                        "outputName": "review",
                         "files": review_filename,
                         "stagingDir": dir_path,
+                        "preview": True,
                         "tags": ["review", "ftrackreview"]
                     }
                     instance.data["representations"].append(review_repre)

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -64,22 +64,29 @@ class Cinema4DExtractReview(publish.Extractor):
             # Identify extension
             ext = os.path.splitext(seq_files[0])[1].lstrip(".").lower()
 
+            # Check for Alpha sequence
+            is_alpha = os.path.basename(seq_files[0]).lower().startswith("a_")
+
             # Main representation (sequence or movie)
             representation = {
-                "name": ext,
+                "name": "alpha" if is_alpha else ext,
                 "ext": ext,
                 "files": seq_files if len(seq_files) > 1 else seq_files[0],
                 "stagingDir": dir_path,
             }
 
+            if is_alpha:
+                representation["outputName"] = "alpha"
+
             # If it is a video file, tag it as review
-            if ext in ["mp4", "mov"]:
+            if ext in ["mp4", "mov"] and not is_alpha:
                 representation["tags"] = ["review", "preview", "ftrackreview"]
 
             instance.data.setdefault("representations", []).append(representation)
 
             # If it is an image sequence, we want to generate a review MP4
-            if ext not in ["mp4", "mov"] and len(seq_files) > 1:
+            # Skip alpha sequences for review generation
+            if ext not in ["mp4", "mov"] and len(seq_files) > 1 and not is_alpha:
                 # Generate review
                 review_filename = f"{filename}.mp4"
                 review_path = os.path.join(dir_path, review_filename)

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -45,7 +45,7 @@ class Cinema4DExtractReview(publish.Extractor):
                 "height": int(height),
             })
         if fileformat is not None:
-            kwargs.update({"fileformat": fileformat})
+            kwargs.update({"file_format": fileformat})
 
         exporters.render_playblast(path, **kwargs)
 

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -80,7 +80,7 @@ class Cinema4DExtractReview(publish.Extractor):
 
             # If it is a video file, tag it as review
             if ext in ["mp4", "mov"] and not is_alpha:
-                representation["tags"] = ["review", "preview", "ftrackreview"]
+                representation["tags"] = ["review", "ftrackreview"]
 
             instance.data.setdefault("representations", []).append(representation)
 
@@ -128,7 +128,7 @@ class Cinema4DExtractReview(publish.Extractor):
                         "ext": "mp4",
                         "files": review_filename,
                         "stagingDir": dir_path,
-                        "tags": ["review", "preview", "ftrackreview"]
+                        "tags": ["review", "ftrackreview"]
                     }
                     instance.data["representations"].append(review_repre)
                     self.log.info(f"Generated review mp4: {review_path}")


### PR DESCRIPTION
This PR adds the ability to automatically generate an MP4 review file when rendering an image sequence in Cinema 4D (Preview or Redshift). It refactors sequence collection into a shared library and uses ffmpeg to generate the MP4, replacing the legacy `MovieSaver` approach in Redshift extractor.

---
*PR created automatically by Jules for task [4635614372418218833](https://jules.google.com/task/4635614372418218833) started by @AendrewHD*