### PR TITLE
Add burnin support for C4D reviews

### DIFF
--- a/client/ayon_cinema4d/api/exporters.py
+++ b/client/ayon_cinema4d/api/exporters.py
@@ -462,6 +462,9 @@ def render_playblast(filepath,
     rendersettings[c4d.RDATA_XRES] = float(width)
     rendersettings[c4d.RDATA_YRES] = float(height)
 
+    # Use default dict if hw_rendersettings is None
+    if hw_rendersettings is None:
+        hw_rendersettings = {}
     set_hardware_render_settings(hw_rendersettings=hw_rendersettings, renderdata=renderdata)
 
     # Initialize bitmap (required by RenderDocument even if rendering externally)

--- a/client/ayon_cinema4d/api/lib.py
+++ b/client/ayon_cinema4d/api/lib.py
@@ -1,6 +1,7 @@
 """Library functions for Cinema4d."""
 import collections
 import contextlib
+import datetime
 import logging
 import math
 import os
@@ -589,7 +590,59 @@ def collect_sequences(files):
     return sequences
 
 
-def generate_review(files, output_path, fps=24):
+def prepare_burnin_data(burnin_settings, instance, start_frame):
+    """Prepare burnin data from settings and instance data.
+
+    Args:
+        burnin_settings (dict): Burnin settings.
+        instance (pyblish.api.Instance): The instance.
+        start_frame (int): The start frame.
+
+    Returns:
+        dict: The prepared burnin data or None if disabled.
+    """
+    if not burnin_settings.get("enabled"):
+        return None
+
+    data = burnin_settings.copy()
+
+    # Prepare template data
+    context_data = instance.context.data
+
+    # Safe get for optional data
+    version = instance.data.get("version", context_data.get("version"))
+    if not version:
+        # Try to find from instance name or assume it's collected
+        version = "v001"  # Fallback
+
+    # Date/Time
+    now = datetime.datetime.now()
+    date_str = now.strftime("%Y-%m-%d")
+    time_str = now.strftime("%H:%M")
+
+    replacements = {
+        "{asset}": instance.data.get("folderPath", instance.data.get("asset", "")),
+        "{task}": instance.data.get("task", ""),
+        "{version}": str(version),
+        "{date}": date_str,
+        "{time}": time_str,
+    }
+
+    # Perform replacements on position keys
+    for key in ["top_left", "top_center", "top_right", "bottom_left", "bottom_center", "bottom_right"]:
+        text = data.get(key)
+        if text:
+            for src, dst in replacements.items():
+                text = text.replace(src, str(dst))
+            data[key] = text
+
+    # Add start frame
+    data["start_frame"] = start_frame
+
+    return data
+
+
+def generate_review(files, output_path, fps=24, burnin_data=None):
     """
     Generate MP4 review from a list of image files using ffmpeg.
 
@@ -597,6 +650,7 @@ def generate_review(files, output_path, fps=24):
         files (list): List of image filenames.
         output_path (str): Full path to output MP4 file.
         fps (float): Frame rate.
+        burnin_data (dict, optional): Burnin configuration and values.
     """
     log = logging.getLogger(__name__)
 
@@ -620,6 +674,56 @@ def generate_review(files, output_path, fps=24):
     # We construct the command
     ffmpeg_cmd = get_ffmpeg_tool_args("ffmpeg")
 
+    vf_filters = ["pad=ceil(iw/2)*2:ceil(ih/2)*2"]
+
+    if burnin_data and burnin_data.get("enabled"):
+        # Extract settings
+        font_size = burnin_data.get("font_size", 42)
+        font_color = burnin_data.get("font_color", "white")
+        font_path = burnin_data.get("font_path", "")
+
+        # Prepare drawtext args
+        # Add shadow for better readability
+        common_args = f"fontsize={font_size}:fontcolor={font_color}:shadowcolor=black:shadowx=2:shadowy=2"
+        if font_path:
+            # Escape path for ffmpeg: backslashes need to be doubled or
+            # replaced by forward slashes, and colons escaped.
+            safe_font_path = font_path.replace("\\", "/").replace(":", "\\:")
+            common_args += f":fontfile='{safe_font_path}'"
+
+        # Define positions
+        # x, y, text_key
+        positions = {
+            "top_left": ("10", "10", "top_left"),
+            "top_center": ("(w-text_w)/2", "10", "top_center"),
+            "top_right": ("w-text_w-10", "10", "top_right"),
+            "bottom_left": ("10", "h-text_h-10", "bottom_left"),
+            "bottom_center": ("(w-text_w)/2", "h-text_h-10", "bottom_center"),
+            "bottom_right": ("w-text_w-10", "h-text_h-10", "bottom_right"),
+        }
+
+        for key, (x, y, text_key) in positions.items():
+            text = burnin_data.get(text_key)
+            if text:
+                # Handle substitutions
+                # {frame} -> %{n + start_frame}
+                start_frame = burnin_data.get("start_frame", 0)
+
+                if "{frame}" in text:
+                    # Escape the text for drawtext
+                    # We want to replace {frame} with %{eif:n+start_frame:d}
+                    repl = f"%{{eif:n+{start_frame}:d}}"
+                    text = text.replace("{frame}", repl)
+
+                # Escape single quotes and colons in text
+                safe_text = text.replace("'", "'\\''").replace(":", "\\:")
+
+                drawtext = f"drawtext={common_args}:text='{safe_text}':x={x}:y={y}"
+                vf_filters.append(drawtext)
+
+    # Join filters
+    vf_chain = ",".join(vf_filters)
+
     cmd = ffmpeg_cmd + [
         "-y",  # Overwrite
         "-r", str(fps),  # Input fps
@@ -628,7 +732,7 @@ def generate_review(files, output_path, fps=24):
         "-i", list_file_path,
         "-c:v", "libx264",
         "-pix_fmt", "yuv420p",
-        "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",  # Ensure even dimensions
+        "-vf", vf_chain,
         output_path
     ]
 

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -221,8 +221,12 @@ class ExtractRedshiftRender(publish.Extractor):
                 review_path = os.path.join(staging_dir, review_filename)
 
                 # Burnin Data
-                settings = instance.context.data["project_settings"]["cinema4d"]["publish"]["ExtractRedshiftRender"]["burnin"]
-                burnin_data = lib.prepare_burnin_data(settings, instance, frame_start)
+                project_settings = instance.context.data["project_settings"]["cinema4d"]
+                if "publish" in project_settings:
+                    settings = project_settings["publish"]["ExtractRedshiftRender"]["burnin"]
+                    burnin_data = lib.prepare_burnin_data(settings, instance, frame_start)
+                else:
+                    burnin_data = None
 
                 try:
                     lib.generate_review(

--- a/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_redshift_render.py
@@ -219,8 +219,15 @@ class ExtractRedshiftRender(publish.Extractor):
             ):
                 review_filename = f"{filename_base}_review.mp4"
                 review_path = os.path.join(staging_dir, review_filename)
+
+                # Burnin Data
+                settings = instance.context.data["project_settings"]["cinema4d"]["publish"]["ExtractRedshiftRender"]["burnin"]
+                burnin_data = lib.prepare_burnin_data(settings, instance, frame_start)
+
                 try:
-                    lib.generate_review(seq_files, review_path, fps=fps)
+                    lib.generate_review(
+                        seq_files, review_path, fps=fps, burnin_data=burnin_data
+                    )
 
                     review_repre = {
                         "name": "mp4",

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -71,6 +71,7 @@ class Cinema4DExtractReview(publish.Extractor):
             "doc": doc,
             "useAlpha": alpha,
             "separate_alpha": separate_alpha,
+            "hw_rendersettings": hw_rendersettings,
         }
         if width is not None and height is not None:
             kwargs.update({

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -155,8 +155,12 @@ class Cinema4DExtractReview(publish.Extractor):
                 fps = instance.data.get("fps", doc.GetFps())
 
                 # Burnin Data
-                settings = instance.context.data["project_settings"]["cinema4d"]["publish"]["Cinema4DExtractReview"]["burnin"]
-                burnin_data = lib.prepare_burnin_data(settings, instance, start)
+                project_settings = instance.context.data["project_settings"]["cinema4d"]
+                if "publish" in project_settings:
+                    settings = project_settings["publish"]["Cinema4DExtractReview"]["burnin"]
+                    burnin_data = lib.prepare_burnin_data(settings, instance, start)
+                else:
+                    burnin_data = None
 
                 try:
                     lib.generate_review(

--- a/client/ayon_cinema4d/plugins/publish/extract_review.py
+++ b/client/ayon_cinema4d/plugins/publish/extract_review.py
@@ -153,8 +153,14 @@ class Cinema4DExtractReview(publish.Extractor):
                 # FPS
                 fps = instance.data.get("fps", doc.GetFps())
 
+                # Burnin Data
+                settings = instance.context.data["project_settings"]["cinema4d"]["publish"]["Cinema4DExtractReview"]["burnin"]
+                burnin_data = lib.prepare_burnin_data(settings, instance, start)
+
                 try:
-                    lib.generate_review(seq_files, review_path, fps=fps)
+                    lib.generate_review(
+                        seq_files, review_path, fps=fps, burnin_data=burnin_data
+                    )
 
                     review_repre = {
                         "name": "mp4",

--- a/server/publish.py
+++ b/server/publish.py
@@ -1,0 +1,39 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class BurninOptionsModel(BaseSettingsModel):
+    enabled: bool = SettingsField(False, title="Enabled")
+    font_size: int = SettingsField(24, title="Font Size", ge=1)
+    font_color: str = SettingsField("white", title="Font Color")
+    font_path: str = SettingsField("", title="Font Path (Optional)")
+    top_left: str = SettingsField("{asset}", title="Top Left")
+    top_center: str = SettingsField("{task}", title="Top Center")
+    top_right: str = SettingsField("{version}", title="Top Right")
+    bottom_left: str = SettingsField("{date}", title="Bottom Left")
+    bottom_center: str = SettingsField("{time}", title="Bottom Center")
+    bottom_right: str = SettingsField("Frame: {frame}", title="Bottom Right")
+
+
+class ExtractReviewModel(BaseSettingsModel):
+    burnin: BurninOptionsModel = SettingsField(
+        default_factory=BurninOptionsModel,
+        title="Burnin"
+    )
+
+
+class ExtractRedshiftRenderModel(BaseSettingsModel):
+    burnin: BurninOptionsModel = SettingsField(
+        default_factory=BurninOptionsModel,
+        title="Burnin"
+    )
+
+
+class PublishPluginsModel(BaseSettingsModel):
+    Cinema4DExtractReview: ExtractReviewModel = SettingsField(
+        default_factory=ExtractReviewModel,
+        title="Render Review"
+    )
+    ExtractRedshiftRender: ExtractRedshiftRenderModel = SettingsField(
+        default_factory=ExtractRedshiftRenderModel,
+        title="Render Redshift"
+    )

--- a/server/settings.py
+++ b/server/settings.py
@@ -8,6 +8,10 @@ from .create import (
     CreatePluginsModel,
     DEFAULT_CINEMA4D_CREATE_SETTINGS
 )
+from .publish import (
+    PublishPluginsModel,
+)
+
 
 class Cinema4DSettings(BaseSettingsModel):
     imageio: Cinema4DImageIOModel = SettingsField(
@@ -18,8 +22,46 @@ class Cinema4DSettings(BaseSettingsModel):
         default_factory=CreatePluginsModel,
         title="Create Plugins"
     )
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
+        title="Publish Plugins"
+    )
+
+
+DEFAULT_PUBLISH_SETTINGS = {
+    "Cinema4DExtractReview": {
+        "burnin": {
+            "enabled": False,
+            "font_size": 42,
+            "font_color": "white",
+            "font_path": "",
+            "top_left": "{asset}",
+            "top_center": "{task}",
+            "top_right": "{version}",
+            "bottom_left": "{date}",
+            "bottom_center": "{time}",
+            "bottom_right": "Frame: {frame}"
+        }
+    },
+    "ExtractRedshiftRender": {
+        "burnin": {
+            "enabled": False,
+            "font_size": 42,
+            "font_color": "white",
+            "font_path": "",
+            "top_left": "{asset}",
+            "top_center": "{task}",
+            "top_right": "{version}",
+            "bottom_left": "{date}",
+            "bottom_center": "{time}",
+            "bottom_right": "Frame: {frame}"
+        }
+    }
+}
+
 
 DEFAULT_VALUES = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
-    "create": DEFAULT_CINEMA4D_CREATE_SETTINGS
+    "create": DEFAULT_CINEMA4D_CREATE_SETTINGS,
+    "publish": DEFAULT_PUBLISH_SETTINGS,
 }


### PR DESCRIPTION
Implemented burnin support for Cinema 4D review extraction. Users can now configure burnin text (asset, task, version, date, time, frame) via project settings for review and Redshift render extractors. The burnins are applied during the FFmpeg MP4 generation process.

---
*PR created automatically by Jules for task [4543576639895014618](https://jules.google.com/task/4543576639895014618) started by @AendrewHD*